### PR TITLE
support more configs for processor and connection

### DIFF
--- a/nifi/client.go
+++ b/nifi/client.go
@@ -146,6 +146,7 @@ type ProcessorRelationship struct {
 type ProcessorConfig struct {
 	SchedulingStrategy               string `json:"schedulingStrategy"`
 	SchedulingPeriod                 string `json:"schedulingPeriod"`
+	ExecutionNode                    string `json:"executionNode"`
 	ConcurrentlySchedulableTaskCount int    `json:"concurrentlySchedulableTaskCount"`
 
 	Properties                  map[string]interface{} `json:"properties"`
@@ -275,6 +276,8 @@ type ConnectionHand struct {
 type ConnectionComponent struct {
 	Id                    string         `json:"id,omitempty"`
 	ParentGroupId         string         `json:"parentGroupId"`
+	BackPressureDataSizeThreshold	string	`json:"backPressureDataSizeThreshold"`
+	BackPressureObjectThreshold		int	`json:"backPressureObjectThreshold"`
 	Source                ConnectionHand `json:"source"`
 	Destination           ConnectionHand `json:"destination"`
 	SelectedRelationships []string       `json:"selectedRelationships"`

--- a/nifi/resource_connection.go
+++ b/nifi/resource_connection.go
@@ -26,6 +26,16 @@ func ResourceConnection() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"back_pressure_data_size_threshold": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default: "1 GB",
+						},
+						"back_pressure_object_threshold": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default: 10000,
+						},
 						"source": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -304,6 +314,9 @@ func ConnectionFromSchema(d *schema.ResourceData, connection *Connection) error 
 	component := v[0].(map[string]interface{})
 	connection.Component.ParentGroupId = component["parent_group_id"].(string)
 
+	connection.Component.BackPressureDataSizeThreshold = component["back_pressure_data_size_threshold"].(string)
+	connection.Component.BackPressureObjectThreshold = component["back_pressure_object_threshold"].(int)
+
 	v = component["source"].([]interface{})
 	if len(v) != 1 {
 		return fmt.Errorf("Exactly one component.source is required")
@@ -366,6 +379,8 @@ func ConnectionToSchema(d *schema.ResourceData, connection *Connection) error {
 
 	component := []map[string]interface{}{{
 		"parent_group_id": d.Get("parent_group_id").(string),
+		"back_pressure_data_size_threshold": connection.Component.BackPressureDataSizeThreshold,
+		"back_pressure_object_threshold": connection.Component.BackPressureObjectThreshold,
 		"source": []map[string]interface{}{{
 			"type": 	connection.Component.Source.Type,
 			"id":   	connection.Component.Source.Id,

--- a/nifi/resource_processor.go
+++ b/nifi/resource_processor.go
@@ -55,6 +55,11 @@ func ResourceProcessor() *schema.Resource {
 										Optional: true,
 										Default:  "0 sec",
 									},
+									"execution_node": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "ALL",
+									},
 									"properties": {
 										Type:     schema.TypeMap,
 										Required: true,
@@ -356,6 +361,7 @@ func ProcessorFromSchema(d *schema.ResourceData, processor *Processor) error {
 
 	processor.Component.Config.SchedulingStrategy = config["scheduling_strategy"].(string)
 	processor.Component.Config.SchedulingPeriod = config["scheduling_period"].(string)
+	processor.Component.Config.ExecutionNode = config["execution_node"].(string)
 	processor.Component.Config.ConcurrentlySchedulableTaskCount = config["concurrently_schedulable_task_count"].(int)
 
 	processor.Component.Config.Properties = map[string]interface{}{}
@@ -397,6 +403,7 @@ func ProcessorToSchema(d *schema.ResourceData, processor *Processor) error {
 			"concurrently_schedulable_task_count": processor.Component.Config.ConcurrentlySchedulableTaskCount,
 			"scheduling_strategy":                 processor.Component.Config.SchedulingStrategy,
 			"scheduling_period":                   processor.Component.Config.SchedulingPeriod,
+			"execution_node":                      processor.Component.Config.ExecutionNode,
 			"properties":                          processor.Component.Config.Properties,
 			"auto_terminated_relationships":       relationships,
 		}},


### PR DESCRIPTION
Changes:
- support executionNode for processor
- support backPressureDataSizeThreshold and backPressureObjectThreshold for connection