### PR TITLE
Fix for #14 bug internal validation of the provider failed for terraform version 0.11.3

### DIFF
--- a/examples/local_flow/main.tf
+++ b/examples/local_flow/main.tf
@@ -45,11 +45,13 @@ resource "nifi_connection" "generate_to_merge_1" {
     source {
       type = "PROCESSOR"
       id = "${nifi_processor.generate_flowfile.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     destination {
       type = "PROCESSOR"
       id = "${nifi_processor.merge_content_1.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     selected_relationships = [
@@ -97,11 +99,13 @@ resource "nifi_connection" "merge_1_to_merge_2" {
     source {
       type = "PROCESSOR"
       id = "${nifi_processor.merge_content_1.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     destination {
       type = "PROCESSOR"
       id = "${nifi_processor.merge_content_2.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     selected_relationships = [
@@ -149,11 +153,13 @@ resource "nifi_connection" "merge_2_to_merge_2" {
     source {
       type = "PROCESSOR"
       id = "${nifi_processor.merge_content_2.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     destination {
       type = "PROCESSOR"
       id = "${nifi_processor.merge_content_2.id}"
+      group_id = "${nifi_process_group.local_flow.id}"
     }
 
     selected_relationships = [

--- a/nifi/client.go
+++ b/nifi/client.go
@@ -673,7 +673,7 @@ type RemoteProcessGroupComponent struct {
 	Name              string   `json:"name"`
 	Position          Position `json:"position"`
 	TargetUris        string   `json:"targetUris"`
-	TransportProtocol string   `json:"transportProtocol"`
+	TransportProtocol string   `json:"transport_protocol"`
 }
 
 type RemoteProcessGroup struct {

--- a/nifi/client.go
+++ b/nifi/client.go
@@ -673,7 +673,7 @@ type RemoteProcessGroupComponent struct {
 	Name              string   `json:"name"`
 	Position          Position `json:"position"`
 	TargetUris        string   `json:"targetUris"`
-	TransportProtocol string   `json:"transport_protocol"`
+	TransportProtocol string   `json:"transportProtocol"`
 }
 
 type RemoteProcessGroup struct {

--- a/nifi/resource_remote_process_group.go
+++ b/nifi/resource_remote_process_group.go
@@ -36,7 +36,7 @@ func ResourceRemoteProcessGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"transportProtocol": {
+						"transport_protocol": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "http",


### PR DESCRIPTION
The issue is resolved after adding the `group_id` to the main.tf file in the local examples to run the .tf file. 

The other issue about validation was because of the capital `P` in `transportProtocol` field name in the client.go and resource_remote_process_group.go files. The validation comes from https://github.com/hashicorp/terraform/blob/df9446f4907cfa74663c5d6fe6848c8f0bc25416/helper/schema/schema.go#L745. 

Issue is resolved once it is changed from `transportProtocol` to `transport_protocol`. 