### PR TITLE
feat: add configurable http scheme

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -5,10 +5,11 @@
 ```
 # Configure the NiFi provider
 provider "nifi" {
-  host       = "localhost:8080"
-  api_path   = "nifi-api"
-  admin_cert = "certs/nifi.crt"
-  admin_key  = "certs/nifi.key"
+  host        = "localhost:8080"
+  api_path    = "nifi-api"
+  admin_cert  = "certs/nifi.crt"
+  admin_key   = "certs/nifi.key"
+  http_scheme = "http"
 }
 ```
 
@@ -16,9 +17,10 @@ provider "nifi" {
 
 The following arguments are supported:
 
-Argument       | Required | Description
----------------|----------|------------
-**host**       | Yes      | NiFi host including port, e.g. `localhost:8080`.
-**api_path**   | No       | API path prefix, e.g. `nifi-api`. Defaults to that.
-**admin_cert** | No       | Path to certificate used to access admin. Provider will use HTTPS only if this is specified. 
-**admin_key**  | No       | Path to certificate's key, required if `admin_cert` is specified.
+Argument         | Required | Description
+-----------------|----------|------------
+**host**         | Yes      | NiFi host including port, e.g. `localhost:8080`.
+**api_path**     | No       | API path prefix, e.g. `nifi-api`. Defaults to that.
+**admin_cert**   | No       | Path to certificate used to access admin. Provider will use HTTPS only if this is specified.
+**admin_key**    | No       | Path to certificate's key, required if `admin_cert` is specified.
+**http_scheme**  | No       | Force a HTTP scheme. Useful if NiFi does not handle SSL termination. Defaults to `http`, unless `admin_cert` and `admin_key` are set, in which case `https` is used.

--- a/nifi/client.go
+++ b/nifi/client.go
@@ -26,7 +26,7 @@ type Client struct {
 
 func NewClient(config Config) *Client {
 	httpClient := &http.Client{}
-	scheme := "http"
+	scheme := config.HttpScheme
 	if config.AdminCertPath != "" && config.AdminKeyPath != "" {
 		cert, err := tls.LoadX509KeyPair(config.AdminCertPath, config.AdminKeyPath)
 		if err != nil {

--- a/nifi/config.go
+++ b/nifi/config.go
@@ -7,4 +7,5 @@ type Config struct {
 	ApiPath       string
 	AdminCertPath string
 	AdminKeyPath  string
+	HttpScheme    string
 }

--- a/nifi/provider.go
+++ b/nifi/provider.go
@@ -14,7 +14,11 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NIFI_HOST", nil),
 			},
-
+			"http_scheme": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NIFI_HTTP_SCHEME", "http"),
+			},
 			"api_path": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -52,6 +56,7 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:          d.Get("host").(string),
+		HttpScheme:    d.Get("http_scheme").(string),
 		ApiPath:       d.Get("api_path").(string),
 		AdminCertPath: d.Get("admin_cert").(string),
 		AdminKeyPath:  d.Get("admin_key").(string),


### PR DESCRIPTION
Intended usecase: NiFi is running behind a reverse proxy, which handles SSL
termination.

In such cases, `https` needs to be used, regardless of whether
`AdminCertPath`/`AdminKeyPath` is set. Without this, the following is
thrown:

```
Error: Error refreshing state: 4 error(s) occurred:

* module.nifi_example.nifi_process_group.example_process_group: 1 error(s) occurred:

* module.nifi_example.nifi_process_group.example_process_group: nifi_process_group.example_process_group: unexpected EOF
panic: runtime error: invalid memory address or nil pointer dereference
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x55c12311f101]
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: goroutine 76 [running]:
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/nifi.(*Client).JsonCall(0xc4202aeaf0, 0x55c12319d82f, 0x3, 0xc42013c540, 0x67, 0x0, 0x0, 0x55c123525780, 0xc4203a5310, 0x0, ...)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/nifi/client.go:82 +0x191
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/nifi.(*Client).GetProcessGroup(0xc4202aeaf0, 0xc4203a2960, 0x24, 0xc42022e800, 0x7a, 0x7f7d1b38e6c8)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/nifi/client.go:126 +0x20d
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/nifi.ResourceProcessGroupExists(0xc4202aeb60, 0x55c12362ee20, 0xc4202aeaf0, 0x24, 0x55c123993420, 0xc4203d5600)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/nifi/resource_process_group.go:136 +0x9e
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc4203e4240, 0xc4203a52c0, 0x55c12362ee20, 0xc4202aeaf0, 0xc42019fcf8, 0x55c122cfa801, 0x55c123526500)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:291 +0x342
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc4202ae230, 0xc4203a5270, 0xc4203a52c0, 0xc4202ae230, 0xc4203d5590, 0xc4203fa0c0)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:267 +0x9c
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Refresh(0xc42037fb80, 0xc4203e3a90, 0xc4203e3b60, 0x0, 0x0)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /root/go/src/github.com/glympse/terraform-provider-nifi/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:510 +0x50
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: reflect.Value.call(0xc420134f60, 0xc42022aad0, 0x13, 0x55c12319dcfc, 0x4, 0xc420051f18, 0x3, 0x3, 0xc4201c0880, 0xc42024a6e8, ...)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /usr/lib/go/src/reflect/value.go:447 +0x96b
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: reflect.Value.Call(0xc420134f60, 0xc42022aad0, 0x13, 0xc42024a718, 0x3, 0x3, 0xc4201d8060, 0xc400000002, 0x0)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /usr/lib/go/src/reflect/value.go:308 +0xa6
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: net/rpc.(*service).call(0xc4203de1c0, 0xc4203e0550, 0xc4203da170, 0xc4203da180, 0xc420228900, 0xc4203ceb80, 0x55c1235264c0, 0xc4203e3a90, 0x16, 0x55c123526500, ...)
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /usr/lib/go/src/net/rpc/server.go:384 +0x150
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi: created by net/rpc.(*Server).ServeCodec
2018-12-14T12:24:50.355Z [DEBUG] plugin.terraform-provider-nifi:        /usr/lib/go/src/net/rpc/server.go:480 +0x43c
2018-12-14T12:24:50.359Z [DEBUG] plugin: plugin process exited: path=/root/.terraform.d/plugins/linux_amd64/terraform-provider-nifi
2018/12/14 12:24:50 [ERROR] root.nifi: eval: *terraform.EvalRefresh, err: nifi_controller_service.aws_credentials_controller: unexpected EOF

<snip>

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Terraform[1] so that we can fix this.

When reporting bugs, please include your terraform version. That
information is available on the first line of crash.log. You can also
get it by running 'terraform --version' on the command line.

[1]: https://github.com/hashicorp/terraform/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

```

Example usage:

```hcl
provider "nifi" {
  host        = "${var.nifi_host}"
  http_scheme = "https"
}
```